### PR TITLE
Fix Wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 
 [dependencies]
 rand = "0.8"
-rug = { version = "1.10", default-features = false, features = ["integer", "serde", "rand"] }
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"
 num-integer = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,14 @@ description = "Non-native arithmetic for SNARKs"
 documentation = "https://docs.rs/bellperson-nonnative"
 license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
+edition = "2021"
 
 [dependencies]
-rand = "0.4"
+rand = "0.8"
 rug = { version = "1.10", default-features = false, features = ["integer", "serde", "rand"] }
+num-bigint = { version = "0.4", features = ["serde", "rand"] }
+num-traits = "0.2"
+num-integer = "0.1"
 bellperson = { version = "0.20", default-features = false }
 ff = { version = "0.11", features = ["derive"] }
 byteorder = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,8 @@
-extern crate bellperson;
-extern crate ff;
-extern crate rand;
-extern crate rug;
-
 #[cfg(test)]
 extern crate quickcheck;
 #[cfg(test)]
 #[macro_use(quickcheck)]
 extern crate quickcheck_macros;
-extern crate byteorder;
 
 #[macro_use]
 pub mod util;

--- a/src/mp/poly.rs
+++ b/src/mp/poly.rs
@@ -4,7 +4,7 @@ use ff::PrimeField;
 use std::cmp::max;
 use std::fmt::{self, Debug, Formatter};
 
-use OptionExt;
+use crate::OptionExt;
 
 pub struct Polynomial<Scalar: PrimeField> {
     pub coefficients: Vec<LinearCombination<Scalar>>,

--- a/src/util/bit.rs
+++ b/src/util/bit.rs
@@ -5,7 +5,7 @@ use ff::PrimeField;
 
 use std::fmt::{self, Display, Formatter};
 
-use OptionExt;
+use crate::OptionExt;
 
 #[derive(Clone)]
 /// A representation of a bit

--- a/src/util/convert.rs
+++ b/src/util/convert.rs
@@ -1,6 +1,6 @@
 use byteorder::WriteBytesExt;
 use ff::PrimeField;
-use rug::{integer::Order, Integer};
+use num_bigint::{BigInt, Sign};
 use std::io::{self, Write};
 
 fn write_be<F: PrimeField, W: Write>(f: &F, mut writer: W) -> io::Result<()> {
@@ -12,15 +12,15 @@ fn write_be<F: PrimeField, W: Write>(f: &F, mut writer: W) -> io::Result<()> {
 }
 
 /// Convert a field element to a natural number
-pub fn f_to_nat<Scalar: PrimeField>(f: &Scalar) -> Integer {
+pub fn f_to_nat<Scalar: PrimeField>(f: &Scalar) -> BigInt {
     let mut s = Vec::new();
     write_be(f, &mut s).unwrap(); // f.to_repr().write_be(&mut s).unwrap();
-    Integer::from_digits(f.to_repr().as_ref(), Order::Lsf)
+    BigInt::from_bytes_le(Sign::Plus, f.to_repr().as_ref())
 }
 
 /// Convert a natural number to a field element.
 /// Returns `None` if the number is too big for the field.
-pub fn nat_to_f<Scalar: PrimeField>(n: &Integer) -> Option<Scalar> {
+pub fn nat_to_f<Scalar: PrimeField>(n: &BigInt) -> Option<Scalar> {
     Scalar::from_str_vartime(&format!("{}", n))
 }
 
@@ -47,14 +47,14 @@ mod test {
 
     #[test]
     fn test_nat_to_f() {
-        let n = Integer::from(4usize);
+        let n = BigInt::from(4usize);
         let e = Fr::from_str_vartime("4").unwrap();
         assert!(nat_to_f::<Fr>(&n).unwrap() == e);
     }
 
     #[test]
     fn test_f_to_nat() {
-        let n = Integer::from(4usize);
+        let n = BigInt::from(4usize);
         let e = Fr::from_str_vartime("4").unwrap();
         assert!(f_to_nat(&e) == n)
     }

--- a/src/util/gadget.rs
+++ b/src/util/gadget.rs
@@ -3,7 +3,7 @@ use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
 use ff::PrimeField;
 
 use super::bit::Bit;
-use OptionExt;
+use crate::OptionExt;
 
 pub trait Gadget: Sized + Clone {
     type Scalar: PrimeField;

--- a/src/util/num.rs
+++ b/src/util/num.rs
@@ -3,9 +3,9 @@ use bellperson::{ConstraintSystem, LinearCombination, SynthesisError, Variable};
 use ff::PrimeField;
 
 use super::bit::{Bit, Bitvector};
+use crate::BitAccess;
+use crate::OptionExt;
 use std::convert::From;
-use BitAccess;
-use OptionExt;
 
 pub struct Num<Scalar: PrimeField> {
     pub num: LinearCombination<Scalar>,


### PR DESCRIPTION
In #2 I missed that `rug` doesn't compile to Wasm due to its dependence on `gmp-mpfr-sys`, which doesn't support [cross-compilation](https://gitlab.com/tspiteri/gmp-mpfr-sys/-/issues/18).

Would you be open to replacing it with `num-bigint`, which is Wasm-compatible? It may have slightly different behavior, for example the `to_f64()` method in `src/mp/bignat.rs` now errors on overflow instead of truncating or returning `f64::INFINITY`, as seen in the [docs](https://docs.rs/rug/latest/rug/struct.Integer.html#method.to_f64). This would also have to be changed in Nova.

I also updated the crate to the Rust 2021 edition for feature resolution and peace of mind but it's not necessary.