### PR TITLE
Wasm support with bellperson 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["zkSNARKs", "cryptography", "proofs"]
 edition = "2021"
 
 [dependencies]
-rand = "0.8"
+rand = { version = "0.8", default-features = false }
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"
 num-integer = "0.1"
@@ -17,7 +17,7 @@ ff = { version = "0.12", features = ["derive"] }
 byteorder = "0.3.0"
 
 [features]
-default = ["bellperson/default"]
+default = []
 
 [dev-dependencies]
 quickcheck = "0.8"


### PR DESCRIPTION
Disables `rand` default features as they contain `getrandom`, which doesn't compile to Wasm without an additional `js` feature. Also with the new `bellperson` the only default feature is `groth16`, which I believe isn't needed here.