### PR TITLE
Update ff to version 0.13

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Build and Test bellperson-nonnative
+name: Build and Test bellpepper-nonnative
 
 on:
   push:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bellperson-nonnative"
-version = "0.4.0"
+version = "0.5.0"
 description = "Non-native arithmetic for SNARKs"
 documentation = "https://docs.rs/bellperson-nonnative"
 license-file = "LICENSE"
@@ -12,8 +12,8 @@ rand = { version = "0.8", default-features = false }
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"
 num-integer = "0.1"
-bellperson = { version = "0.24", default-features = false }
-ff = { version = "0.12", features = ["derive"] }
+bellperson = { version = "0.25", default-features = false }
+ff = { version = "0.13", features = ["derive"] }
 byteorder = "0.3.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ rand = { version = "0.8", default-features = false }
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"
 num-integer = "0.1"
-bellpepper-core = { version = "0.2.0", default-features = false }
-bellpepper = { version = "0.2.0", default-features = false }
+bellpepper-core = { version = "0.4.0", default-features = false }
+bellpepper = { version = "0.4.0", default-features = false }
 ff = { version = "0.13", features = ["derive"] }
 byteorder = "0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "bellperson-nonnative"
-version = "0.5.0"
+name = "bellpepper-nonnative"
+version = "0.1.0"
 description = "Non-native arithmetic for SNARKs"
-documentation = "https://docs.rs/bellperson-nonnative"
+documentation = "https://docs.rs/bellpepper-nonnative"
 license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
 edition = "2021"
@@ -12,7 +12,8 @@ rand = { version = "0.8", default-features = false }
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"
 num-integer = "0.1"
-bellperson = { version = "0.25", default-features = false }
+bellpepper-core = { version = "0.2.0", default-features = false }
+bellpepper = { version = "0.2.0", default-features = false }
 ff = { version = "0.13", features = ["derive"] }
 byteorder = "0.3.0"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# bellperson-nonnative
+# bellpepper-nonnative
 
 This is a fork of [`bellman-bignat`](https://github.com/alex-ozdemir/bellman-bignat) library, with the following "small" modifications:
 
-* Uses bellperson, a fork of `bellman`, instead of `bellman`
+* Uses bellpepper, a fork of `bellperson`, which is itself a fork of `bellman`
 * Trims the library to only provide big-number arithmetic functionality.
 
 Test can be run using `cargo`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate quickcheck_macros;
 pub mod util;
 pub mod mp;
 
-use bellperson::SynthesisError;
+use bellpepper_core::SynthesisError;
 use ff::PrimeField;
 
 trait OptionExt<T> {

--- a/src/mp/bignat.rs
+++ b/src/mp/bignat.rs
@@ -389,7 +389,7 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
         let delta_inv = AllocatedNum::alloc(cs.namespace(|| "delta_inv"), || {
             let delta = delta.get_value().unwrap();
 
-            if delta.is_zero().unwrap_u8() == 0 {
+            if delta.is_zero().unwrap_u8() == 1 {
                 Ok(Scalar::ONE) // we can return any number here, it doesn't matter
             } else {
                 Ok(delta.invert().unwrap())
@@ -1364,6 +1364,7 @@ impl<Scalar: PrimeField> Gadget for BigNat<Scalar> {
 mod tests {
     use super::*;
     use crate::util::convert::usize_to_f;
+    use crate::util::scalar::Fr;
     use crate::util::test_helpers::*;
     use num_traits::Num as BigNum;
     use quickcheck::TestResult;
@@ -1888,6 +1889,26 @@ mod tests {
         let mut cs = TestConstraintSystem::<Fr>::new();
         circuit.synthesize(&mut cs).expect("synthesis failed");
         TestResult::from_bool(cs.is_satisfied())
+    }
+
+    #[test]
+    fn test_equals() {
+        let mut cs = TestConstraintSystem::<Fr>::new();
+
+        let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(Fr::from(3u64))).unwrap();
+        let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(Fr::from(4u64))).unwrap();
+        let c = AllocatedNum::alloc(cs.namespace(|| "c"), || Ok(Fr::from(4u64))).unwrap();
+        let r1 = BigNat::equals(cs.namespace(|| "check unequal"), &a, &b)
+            .unwrap()
+            .get_value()
+            .unwrap();
+        let r2 = BigNat::equals(cs.namespace(|| "check equal"), &b, &c)
+            .unwrap()
+            .get_value()
+            .unwrap();
+
+        assert!(!r1);
+        assert!(r2);
     }
 }
 

--- a/src/mp/bignat.rs
+++ b/src/mp/bignat.rs
@@ -1,7 +1,7 @@
-use bellperson::gadgets::boolean::AllocatedBit;
-use bellperson::gadgets::boolean::Boolean;
-use bellperson::gadgets::num::AllocatedNum;
-use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
+use bellpepper::gadgets::boolean::AllocatedBit;
+use bellpepper::gadgets::boolean::Boolean;
+use bellpepper::gadgets::num::AllocatedNum;
+use bellpepper_core::{ConstraintSystem, LinearCombination, SynthesisError};
 use ff::PrimeField;
 use num_bigint::BigInt;
 use num_integer::Integer;
@@ -11,6 +11,7 @@ use std::borrow::Borrow;
 use std::cmp::{max, min, Ordering};
 use std::convert::From;
 use std::fmt::{self, Debug, Display, Formatter};
+use std::ops::Deref;
 use std::rc::Rc;
 
 use super::poly::Polynomial;
@@ -454,7 +455,7 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
         mut cs: CS,
         other: &Self,
     ) -> Result<Boolean, SynthesisError> {
-        use bellperson::gadgets::num::Num;
+        use bellpepper::gadgets::num::Num;
         let mut rolling = Boolean::Constant(true);
         if self.limbs.len() != other.limbs.len() {
             eprintln!(
@@ -1290,7 +1291,7 @@ impl<Scalar: PrimeField> Gadget for BigNat<Scalar> {
     ) -> Result<Self, SynthesisError> {
         BigNat::alloc_from_nat(
             cs,
-            || Ok(value.grab()?.clone().clone()),
+            || Ok(value.grab()?.clone().deref().clone()),
             params.limb_width,
             params.n_limbs,
         )

--- a/src/mp/bignat.rs
+++ b/src/mp/bignat.rs
@@ -389,7 +389,7 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
             let delta = delta.get_value().unwrap();
 
             if delta.is_zero().unwrap_u8() == 0 {
-                Ok(Scalar::one()) // we can return any number here, it doesn't matter
+                Ok(Scalar::ONE) // we can return any number here, it doesn't matter
             } else {
                 Ok(delta.invert().unwrap())
             }
@@ -474,7 +474,7 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
                 || format!("equal self {}", i),
                 |lc| lc,
                 |lc| lc,
-                |lc| lc - &Num::from(self_limb.clone()).lc(Scalar::one()) + &self.limbs[i],
+                |lc| lc - &Num::from(self_limb.clone()).lc(Scalar::ONE) + &self.limbs[i],
             );
             let other_limb = AllocatedNum::alloc(cs.namespace(|| format!("other {}", i)), || {
                 Ok(other.limb_values.as_ref().grab()?[i])
@@ -483,7 +483,7 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
                 || format!("equal other {}", i),
                 |lc| lc,
                 |lc| lc,
-                |lc| lc - &Num::from(other_limb.clone()).lc(Scalar::one()) + &other.limbs[i],
+                |lc| lc - &Num::from(other_limb.clone()).lc(Scalar::ONE) + &other.limbs[i],
             );
 
             let b = Self::equals(
@@ -554,7 +554,7 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
                     let val =
                         bv.values
                             .as_ref()
-                            .map(|v| if v[i] { Scalar::one() } else { Scalar::zero() });
+                            .map(|v| if v[i] { Scalar::ONE } else { Scalar::ZERO });
                     Num::new(val, bit.clone())
                 })
                 .collect(),
@@ -593,10 +593,10 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
             || "inverse",
             || {
                 Ok({
-                    let mut sum = Scalar::zero();
+                    let mut sum = Scalar::ZERO;
                     for b in &upper_bits {
                         if *b.value.grab()? {
-                            sum.add_assign(&Scalar::one());
+                            sum.add_assign(&Scalar::ONE);
                         }
                     }
                     sum = sum.invert().unwrap();
@@ -723,7 +723,7 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
         let carry_bits =
             (((max_word.to_f64().unwrap() * 2.0).log2() - self.params.limb_width as f64).ceil()
                 + 0.1) as usize;
-        let mut carry_in = Num::new(Some(Scalar::zero()), LinearCombination::zero());
+        let mut carry_in = Num::new(Some(Scalar::ZERO), LinearCombination::zero());
 
         for i in 0..n {
             let carry = Num::alloc(cs.namespace(|| format!("carry value {}", i)), || {
@@ -1183,15 +1183,15 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
     pub fn group_limbs(&self, limbs_per_group: usize) -> BigNat<Scalar> {
         let n_groups = (self.limbs.len() - 1) / limbs_per_group + 1;
         let limb_values = self.limb_values.as_ref().map(|vs| {
-            let mut values: Vec<Scalar> = vec![Scalar::zero(); n_groups];
-            let mut shift = Scalar::one();
-            let limb_block = (0..self.params.limb_width).fold(Scalar::one(), |mut l, _| {
+            let mut values: Vec<Scalar> = vec![Scalar::ZERO; n_groups];
+            let mut shift = Scalar::ONE;
+            let limb_block = (0..self.params.limb_width).fold(Scalar::ONE, |mut l, _| {
                 l = l.double();
                 l
             });
             for (i, v) in vs.iter().enumerate() {
                 if i % limbs_per_group == 0 {
-                    shift = Scalar::one();
+                    shift = Scalar::ONE;
                 }
                 let mut a = shift.clone();
                 // a.mul_assign(&v);
@@ -1204,14 +1204,14 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
         let limbs = {
             let mut limbs: Vec<LinearCombination<Scalar>> =
                 vec![LinearCombination::zero(); n_groups];
-            let mut shift = Scalar::one();
-            let limb_block = (0..self.params.limb_width).fold(Scalar::one(), |mut l, _| {
+            let mut shift = Scalar::ONE;
+            let limb_block = (0..self.params.limb_width).fold(Scalar::ONE, |mut l, _| {
                 l = l.double();
                 l
             });
             for (i, limb) in self.limbs.iter().enumerate() {
                 if i % limbs_per_group == 0 {
-                    shift = Scalar::one();
+                    shift = Scalar::ONE;
                 }
                 limbs[i / limbs_per_group] =
                     std::mem::replace(&mut limbs[i / limbs_per_group], LinearCombination::zero())
@@ -1246,7 +1246,7 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
                 new.params.n_limbs = n_limbs;
                 new.limb_values.as_mut().map(|vs| {
                     while vs.len() < n_limbs {
-                        vs.push(Scalar::zero())
+                        vs.push(Scalar::ZERO)
                     }
                 });
                 while new.limbs.len() < n_limbs {
@@ -1259,7 +1259,7 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
 
     pub fn one<CS: ConstraintSystem<Scalar>>(limb_width: usize) -> Self {
         BigNat {
-            limb_values: Some(vec![Scalar::one()]),
+            limb_values: Some(vec![Scalar::ONE]),
             value: Some(BigInt::from(1)),
             limbs: { vec![LinearCombination::zero() + CS::one()] },
             params: BigNatParams {

--- a/src/mp/bignat.rs
+++ b/src/mp/bignat.rs
@@ -1283,6 +1283,8 @@ impl<Scalar: PrimeField> Gadget for BigNat<Scalar> {
     type Value = BigInt;
     type Params = BigNatParams;
     type Access = ();
+    
+    #[allow(noop_method_call)]
     fn alloc<CS: ConstraintSystem<Scalar>>(
         cs: CS,
         value: Option<&Self::Value>,

--- a/src/mp/poly.rs
+++ b/src/mp/poly.rs
@@ -22,8 +22,8 @@ impl<Scalar: PrimeField> Debug for Polynomial<Scalar> {
 impl<Scalar: PrimeField> Polynomial<Scalar> {
     pub fn evaluate_at(&self, x: Scalar) -> Option<Scalar> {
         self.values.as_ref().map(|vs| {
-            let mut v = Scalar::one();
-            let mut acc = Scalar::zero();
+            let mut v = Scalar::ONE;
+            let mut acc = Scalar::ZERO;
             for coeff in vs {
                 let mut t = coeff.clone();
                 t.mul_assign(&v);
@@ -41,7 +41,7 @@ impl<Scalar: PrimeField> Polynomial<Scalar> {
         let n_product_coeffs = self.coefficients.len() + other.coefficients.len() - 1;
         let values = self.values.as_ref().and_then(|self_vs| {
             other.values.as_ref().map(|other_vs| {
-                let mut values: Vec<Scalar> = std::iter::repeat_with(Scalar::zero)
+                let mut values: Vec<Scalar> = std::iter::repeat_with(|| Scalar::ZERO)
                     .take(n_product_coeffs)
                     .collect();
                 for (self_i, self_v) in self_vs.iter().enumerate() {
@@ -64,14 +64,14 @@ impl<Scalar: PrimeField> Polynomial<Scalar> {
             coefficients,
             values,
         };
-        let one = Scalar::one();
-        let mut x = Scalar::zero();
+        let one = Scalar::ONE;
+        let mut x = Scalar::ZERO;
         for _ in 1..(n_product_coeffs + 1) {
             x.add_assign(&one);
             cs.enforce(
                 || format!("pointwise product @ {:?}", x),
                 |lc| {
-                    let mut i = Scalar::one();
+                    let mut i = Scalar::ONE;
                     self.coefficients.iter().fold(lc, |lc, c| {
                         let r = lc + (i, c);
                         i.mul_assign(&x);
@@ -79,7 +79,7 @@ impl<Scalar: PrimeField> Polynomial<Scalar> {
                     })
                 },
                 |lc| {
-                    let mut i = Scalar::one();
+                    let mut i = Scalar::ONE;
                     other.coefficients.iter().fold(lc, |lc, c| {
                         let r = lc + (i, c);
                         i.mul_assign(&x);
@@ -87,7 +87,7 @@ impl<Scalar: PrimeField> Polynomial<Scalar> {
                     })
                 },
                 |lc| {
-                    let mut i = Scalar::one();
+                    let mut i = Scalar::ONE;
                     product.coefficients.iter().fold(lc, |lc, c| {
                         let r = lc + (i, c);
                         i.mul_assign(&x);
@@ -105,7 +105,7 @@ impl<Scalar: PrimeField> Polynomial<Scalar> {
             other.values.as_ref().map(|other_vs| {
                 (0..n_coeffs)
                     .map(|i| {
-                        let mut s = Scalar::zero();
+                        let mut s = Scalar::ZERO;
                         if i < self_vs.len() {
                             s.add_assign(&self_vs[i]);
                         }

--- a/src/mp/poly.rs
+++ b/src/mp/poly.rs
@@ -1,4 +1,4 @@
-use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
+use bellpepper_core::{ConstraintSystem, LinearCombination, SynthesisError};
 use ff::PrimeField;
 
 use std::cmp::max;
@@ -141,8 +141,8 @@ mod tests {
     use super::*;
     use crate::util::convert::usize_to_f;
     use crate::util::scalar::Fr;
-    use bellperson::gadgets::test::TestConstraintSystem;
-    use bellperson::Circuit;
+    use bellpepper_core::test_cs::TestConstraintSystem;
+    use bellpepper_core::Circuit;
 
     pub struct PolynomialMultiplier<Scalar: PrimeField> {
         pub a: Vec<Scalar>,

--- a/src/util/bit.rs
+++ b/src/util/bit.rs
@@ -1,6 +1,6 @@
 // (mostly from franklin-crypto)
-use bellperson::gadgets::boolean::Boolean;
-use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
+use bellpepper::gadgets::boolean::Boolean;
+use bellpepper_core::{ConstraintSystem, LinearCombination, SynthesisError};
 use ff::PrimeField;
 
 use std::fmt::{self, Display, Formatter};

--- a/src/util/bit.rs
+++ b/src/util/bit.rs
@@ -142,9 +142,9 @@ impl<Scalar: PrimeField> Bit<Scalar> {
             || "boolean",
             || {
                 if *value.grab()? {
-                    Ok(Scalar::one())
+                    Ok(Scalar::ONE)
                 } else {
-                    Ok(Scalar::zero())
+                    Ok(Scalar::ZERO)
                 }
             },
         )?;
@@ -187,7 +187,7 @@ impl<Scalar: PrimeField> Bit<Scalar> {
     }
 
     pub fn from_sapling<CS: ConstraintSystem<Scalar>>(b: Boolean) -> Self {
-        Self::new(b.lc(CS::one(), Scalar::one()), b.get_value())
+        Self::new(b.lc(CS::one(), Scalar::ONE), b.get_value())
     }
 
     pub fn not<CS: ConstraintSystem<Scalar>>(&self) -> Self {

--- a/src/util/gadget.rs
+++ b/src/util/gadget.rs
@@ -1,5 +1,5 @@
-use bellperson::gadgets::num::AllocatedNum;
-use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
+use bellpepper::gadgets::num::AllocatedNum;
+use bellpepper_core::{ConstraintSystem, LinearCombination, SynthesisError};
 use ff::PrimeField;
 
 use super::bit::Bit;

--- a/src/util/num.rs
+++ b/src/util/num.rs
@@ -1,5 +1,5 @@
-use bellperson::gadgets::num::AllocatedNum;
-use bellperson::{ConstraintSystem, LinearCombination, SynthesisError, Variable};
+use bellpepper::gadgets::num::AllocatedNum;
+use bellpepper_core::{ConstraintSystem, LinearCombination, SynthesisError, Variable};
 use ff::PrimeField;
 
 use super::bit::{Bit, Bitvector};

--- a/src/util/num.rs
+++ b/src/util/num.rs
@@ -53,9 +53,9 @@ impl<Scalar: PrimeField> Num<Scalar> {
                     || format!("bit {}", i),
                     || {
                         let r = if *v.grab()?.get_bit(i).grab()? {
-                            Scalar::one()
+                            Scalar::ONE
                         } else {
-                            Scalar::zero()
+                            Scalar::ZERO
                         };
                         Ok(r)
                     },
@@ -76,7 +76,7 @@ impl<Scalar: PrimeField> Num<Scalar> {
         cs.enforce(
             || "last bit",
             |mut lc| {
-                let mut f = Scalar::one();
+                let mut f = Scalar::ONE;
                 lc = lc + &self.num;
                 for v in bits.iter() {
                     f = f.double();
@@ -86,7 +86,7 @@ impl<Scalar: PrimeField> Num<Scalar> {
             },
             |mut lc| {
                 lc = lc + CS::one();
-                let mut f = Scalar::one();
+                let mut f = Scalar::ONE;
                 lc = lc - &self.num;
                 for v in bits.iter() {
                     f = f.double();
@@ -107,7 +107,7 @@ impl<Scalar: PrimeField> Num<Scalar> {
         other: &Bitvector<Scalar>,
     ) -> Result<(), SynthesisError> {
         let allocations = other.allocations.clone();
-        let mut f = Scalar::one();
+        let mut f = Scalar::ONE;
         let sum = allocations
             .iter()
             .fold(LinearCombination::zero(), |lc, bit| {
@@ -145,7 +145,7 @@ impl<Scalar: PrimeField> Num<Scalar> {
                 )
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let mut f = Scalar::one();
+        let mut f = Scalar::ONE;
         let sum = allocations
             .iter()
             .fold(LinearCombination::zero(), |lc, bit| {

--- a/src/util/test_helpers.rs
+++ b/src/util/test_helpers.rs
@@ -1,5 +1,5 @@
-pub use bellperson::gadgets::test::TestConstraintSystem;
-pub use bellperson::Circuit;
+pub use bellpepper_core::test_cs::TestConstraintSystem;
+pub use bellpepper_core::Circuit;
 pub use ff::PrimeField;
 
 macro_rules! circuit_tests {


### PR DESCRIPTION
Changes are similar to the those made to the files in `Nova/src/gadgets/nonnative` as part of https://github.com/microsoft/Nova/pull/162 

Summary
- Changed version of `ff` to 0.13
- Changed version of `bellperson` to 0.25
- Changed version of `bellperson-nonnative` to 0.5.0

All tests passed

```
$ cargo t -r
    Finished release [optimized] target(s) in 0.07s
     Running unittests src/lib.rs (target/release/deps/bellperson_nonnative-2470d17bb5aa73ca)

running 27 tests
test mp::bignat::tests::carry_2limbs_trivial ... ok
test mp::bignat::tests::carry_4limbs_1carry ... ok
test mp::bignat::tests::carry_4limbs_2carry ... ok
test mp::bignat::tests::carry_4limbs_2carry_wrong ... ok
test mp::bignat::tests::decomp_1_into_2b ... ok
test mp::bignat::tests::carry_4limbs_trivial ... ok
test mp::bignat::tests::decomp_5_into_2b_fails ... ok
test mp::bignat::tests::decomp_255_into_8b ... ok
test mp::bignat::tests::carry_4limbs_wrong_trivial ... ok
test mp::bignat::tests::decomp_1_into_1b ... ok
test mp::bignat::tests::mult_mod_1_by_1 ... ok
test mp::bignat::tests::mult_mod_110_by_180_mod187 ... ok
test mp::bignat::tests::mult_mod_16_by_16 ... ok
test mp::bignat::tests::mult_mod_1_by_0 ... ok
test mp::bignat::tests::mult_mod_254_by_254 ... ok
test mp::bignat::tests::mult_mod_2_by_2 ... ok
test mp::bignat::tests::mult_mod_254_by_254_wrong ... ok
test mp::poly::tests::test_circuit ... ok
test util::convert::test::test_f_to_usize ... ok
test util::convert::test::test_f_to_nat ... ok
test util::convert::test::test_nat_to_f ... ok
test util::convert::test::test_usize_to_f ... ok
test mp::bignat::tests::mult_mod_2w_by_6w ... ok
test mp::bignat::tests::mult_mod_2w_by_6w_test_2 ... ok
test mp::bignat::tests::mult_mod_pallas ... ok
test mp::bignat::tests::mult_mod_2048x128 ... ok
test mp::bignat::tests::big_nat_can_decompose ... ok

test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

   Doc-tests bellperson-nonnative

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```